### PR TITLE
Add XBMC support (XBMC service addon 'XBMC MPRIS D-Bus interface' needed)

### DIFF
--- a/src/metadata.json.in
+++ b/src/metadata.json.in
@@ -4,7 +4,7 @@
 "description": "Control MPRIS capable media players",
 "original-author": "eon@patapon.info",
 "shell-version": [ "3.1.90", "3.1.91", "3.1.92", "3.2" ],
-"players": [ "clementine", "mpd", "banshee", "rhythmbox", "rhythmbox3", "pragha", "quodlibet", "guayadeque", "amarok", "googlemusicframe" ],
+"players": [ "clementine", "mpd", "banshee", "rhythmbox", "rhythmbox3", "pragha", "quodlibet", "guayadeque", "amarok", "googlemusicframe", "xbmc" ],
 "support_seek": [ "clementine", "banshee", "rhythmbox", "rhythmbox3", "quodlibet", "amarok" ],
 "locale": "@LOCALEDIR@",
 "path": "@EXTENSIONDIR@",


### PR DESCRIPTION
Add XBMC support (XBMC service addon 'XBMC MPRIS D-Bus interface' needed).
