### PR TITLE
Display correct player name and icon

### DIFF
--- a/src/stylesheet.css
+++ b/src/stylesheet.css
@@ -64,7 +64,7 @@
     padding: .4em 1.74em;
 }
 
-.player-title StIcon {
+.player-title .menu-item-icon {
     icon-size: 16px;
-    padding-right: .5em;
+    padding-right: .4em;
 }


### PR DESCRIPTION
The program name or icon file doesn't always match the bus name; for example, `banshee` vs `media-player-banshee` and `quodlibet` vs "Quod Libet". Use the MPRIS2 _Identity_ and _DesktopEntry_ properties to display correct values.
