### PR TITLE
Add support for Beatbox audio player (http://launchpad.net/beat-box).

### DIFF
--- a/src/metadata.json.in
+++ b/src/metadata.json.in
@@ -10,6 +10,7 @@
 "players": [
     "amarok",
     "banshee",
+    "beatbox",
     "clementine",
     "deadbeef",
     "googlemusicframe",
@@ -26,6 +27,7 @@
 "support_seek": [
     "amarok",
     "banshee",
+    "beatbox",
     "clementine",
     "deadbeef",
     "quodlibet",


### PR DESCRIPTION
BeatBox is already compatible with the D-Bus MPRIS2 spec, so this shouldn't be a problem. Furthermore, I have tested the change by modifying my local extension file to include the player. This player is popular with a certain subset of users of Ubuntu and Ubuntu-based distributions, many of whom also use Gnome-shell.
