### PR TITLE
Add support for nuvola player

### DIFF
--- a/src/metadata.json.in
+++ b/src/metadata.json.in
@@ -14,6 +14,7 @@
     "clementine",
     "deadbeef",
     "googlemusicframe",
+	 "nuvolaplayer",
     "guayadeque",
     "mpd",
     "pithos",


### PR DESCRIPTION
Since version 0.3.2 Google Music Frame changed its name to Nuvola Player.
