### PR TITLE
Add VLC 2.0 support

### DIFF
--- a/src/metadata.json.in
+++ b/src/metadata.json.in
@@ -26,6 +26,7 @@
     "spotify",
     "tomahawk",
     "totem",
+    "vlc",
     "xbmc",
     "xnoise"
 ]


### PR DESCRIPTION
VLC 2.0 has MPRIS v2 support now.
