### PR TITLE
Added gnome shell 3.4.1 to metadata

### DIFF
--- a/src/metadata.json.in
+++ b/src/metadata.json.in
@@ -3,7 +3,7 @@
 "name": "Media player indicator",
 "description": "Control MPRIS2 capable media players",
 "original-author": "eon@patapon.info",
-"shell-version": [ "3.3.5", "3.3.90", "3.3.91", "3.3.92", "3.4" ],
+"shell-version": [ "3.3.5", "3.3.90", "3.3.91", "3.3.92", "3.4", "3.4.1" ],
 "url": "@URL@",
 "locale": "@LOCALEDIR@"
 }


### PR DESCRIPTION
Works wonderful with my ubuntu 12.04 and gnome shell 3.4.1
