### PR TITLE
Fix Brazilian Portuguese translation

### DIFF
--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -25,7 +25,7 @@ msgstr "Parado"
 
 #: ../src/extension.js:51
 msgid "Playing"
-msgstr "Tocando"
+msgstr "Reproduzindo"
 
 #: ../src/extension.js:52
 msgid "Paused"


### PR DESCRIPTION
Both translations are correct but
- "Pausado" is more better than "Em pausa"
- "Reproduzindo" is more better than "Tocando"
