### PR TITLE
Fix multi-instance support

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -888,7 +888,7 @@ const PlayerManager = new Lang.Class({
     },
 
     _changePlayerOwner: function(busName, oldOwner, newOwner) {
-        if (this._players[oldOwner]) {
+        if (this._players[oldOwner] && busName == this._players[oldOwner].player.busName) {
             this._players[newOwner] = this._players[oldOwner];
             this._players[newOwner].player.owner = newOwner;
             delete this._players[oldOwner];


### PR DESCRIPTION
The multi-instance code was broken in several ways, by not correctly changing bus names and owners of Player objects, resulting in leftover players displayed after two or more instances were opened and then closed.

For example, to reproduce with VLC:

```
cvlc & sleep 1; cvlc & sleep 1; cvlc & sleep 1; \
kill %1; sleep 1; kill %2; sleep 1; kill %3
```
