### PR TITLE
Fix issues with multiple default player items.

### DIFF
--- a/src/manager.js
+++ b/src/manager.js
@@ -77,10 +77,7 @@ const PlayerManager = new Lang.Class({
                 this._hideOrDefaultPlayer();
             }))
         );
-        // wait for all players to be loaded
-        Mainloop.timeout_add(500, Lang.bind(this, function() {
-            this._hideOrDefaultPlayer();
-        }));
+        this._hideOrDefaultPlayer();
     },
 
     _isInstance: function(busName) {
@@ -152,14 +149,15 @@ const PlayerManager = new Lang.Class({
             this._addPlayerMenu(this._players[owner].player);
         }
 
-        Mainloop.timeout_add(500, Lang.bind(this, function() {
-            this._hideOrDefaultPlayer();
-        }));
+        this._hideOrDefaultPlayer();
 
         this._refreshStatus();
     },
 
     _hideOrDefaultPlayer: function() {
+        if (this._disabling)
+            return;
+            
         if (this._nbPlayers() == 0 && Settings.gsettings.get_boolean(Settings.MEDIAPLAYER_RUN_DEFAULT)) {
             if (!this._players[Settings.DEFAULT_PLAYER_OWNER]) {
                 let player = new Player.DefaultPlayer();
@@ -241,12 +239,7 @@ const PlayerManager = new Lang.Class({
             if (position)
                 this._removeMenuItem(position);
             delete this._players[owner];
-            // wait for all players to be loaded
-            if (!this._disabling) {
-                Mainloop.timeout_add(500, Lang.bind(this, function() {
-                    this._hideOrDefaultPlayer();
-                }));
-            }
+            this._hideOrDefaultPlayer();
         }
         this._refreshStatus();
     },


### PR DESCRIPTION
This patch should fix issues #127 and #73.
The problem with the async invokation of _hideOrDefaultPlayer() is that when gnome-shell's screen shield ("lock screen") is invoked, the application is enabled and disabled several times (depending on the number of other extensions that are "above" in the extension stack). 
The menu item to start the default player is added 500ms after the enable(), by this time disable() has already been called and the new item never gets removed from the menu, as _removePlayer() cannot see 500ms into the future.

I carefully checked all the async states and I **think** it is save to remove all the 500ms delays now. With _hideOrDefaultPlayer() at the end of _init(), the worst thing that could happen is that a DefaultPlayer is created for very few ms and then destroyed again by _addPlayer() (from the GetNameOwner callback). This should not be a problem, as the dbus callback should be quite fast and noone will notice the default player. If for some reason it _is_ slow, it makes sense to show the default player from the start.
