### PR TITLE
honor CanPlay

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -708,6 +708,19 @@ const MPRISPlayer = new Lang.Class({
                 }
             })
         );
+        this._prop.GetRemote('org.mpris.MediaPlayer2.Player', 'CanPlay',
+            Lang.bind(this, function(value, err) {
+                // assume the player can play by default
+                let canPlay = true;
+                if (!err)
+                    canPlay = value[0].unpack();
+
+                if (canPlay)
+                    this._playButton.enable();
+                else
+                    this._playButton.disable();
+            })
+        );
         this._prop.GetRemote('org.mpris.MediaPlayer2.Player', 'CanGoNext',
             Lang.bind(this, function(value, err) {
                 // assume the player can go next by default

--- a/src/player.js
+++ b/src/player.js
@@ -715,7 +715,7 @@ const MPRISPlayer = new Lang.Class({
                 if (!err)
                     canPlay = value[0].unpack();
 
-                if (canPlay)
+                if (canPlay || this._status != Settings.Status.STOP)
                     this._playButton.enable();
                 else
                     this._playButton.disable();

--- a/src/player.js
+++ b/src/player.js
@@ -597,13 +597,9 @@ const MPRISPlayer = new Lang.Class({
                 this._stopTimer();
             }
 
-            if (Settings.SEND_STOP_ON_CHANGE.indexOf(this.busName) != -1) {
-                // Some players send a "PlaybackStatus: Stopped" signal when changing
-                // tracks, so wait a little before refreshing.
-                Mainloop.timeout_add(300, Lang.bind(this, this._refreshStatus));
-            } else {
-                this._refreshStatus();
-            }
+            // Some players send a "PlaybackStatus: Stopped" signal when changing
+            // tracks, so wait a little before refreshing.
+            Mainloop.timeout_add(300, Lang.bind(this, this._refreshStatus));
         }
     },
 


### PR DESCRIPTION
Sometimes, a player may be unable to start playback, for example when there are no tracks on the playlist. MPRIS reflects this with the CanPlay property. The play button should be inactive according to its value.