### PR TITLE
Update panel.js

### DIFF
--- a/src/panel.js
+++ b/src/panel.js
@@ -65,8 +65,7 @@ const MediaplayerStatusButton = new Lang.Class({
     },
 
     _showCover: function(player) {
-        if (Settings.gsettings.get_enum(Settings.MEDIAPLAYER_STATUS_TYPE_KEY) == Settings.IndicatorStatusType.COVER &&
-                this._coverPath != player.trackCoverPath) {
+        if (Settings.gsettings.get_enum(Settings.MEDIAPLAYER_STATUS_TYPE_KEY) == Settings.IndicatorStatusType.COVER) {
             this._coverPath = player.trackCoverPath;
             // Change cover
             if (this._coverPath && GLib.file_test(this._coverPath, GLib.FileTest.EXISTS)) {


### PR DESCRIPTION
workaround for bug of displaying wrong cover in panel. cover is now refreshed on every play/pause/stop action. this fixes #172