### PR TITLE
Fix undefined variable

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -273,7 +273,6 @@ const PlayerUI = new Lang.Class({
 
     if (newState.status) {
       let status = newState.status;
-      this.status.text = _(status);
 
       if (status == Settings.Status.STOP) {
         this.trackBox.hideAnimate();


### PR DESCRIPTION
The extension currently generates the following error when PlaybackStatus is updated:
````
Gjs-WARNING **: JS ERROR: Exception in callback for signal: player-update: TypeError: this.status is undefined
````
This patch removes the reference to `this.status`. There seems to be no other reference to this variable.