### PR TITLE
Fix hidden position slider

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -494,6 +494,11 @@ const MPRISPlayer = new Lang.Class({
           this.emit('player-update', new PlayerState({showPosition: false}));
         }
         else {
+          if (this.state.showPosition == false &&
+              this._settings.get_boolean(Settings.MEDIAPLAYER_POSITION_KEY)) {
+            // Reenable showPosition after error
+            this.emit('player-update', new PlayerState({showPosition: true}));
+          }
           let position = value[0].unpack() / 1000000;
           this.trackTime = position;
         }


### PR DESCRIPTION
If there is an error asking the mpris player for a position the position slider is hidden. If a later call provides a valid position enable the slider again if it was hidden before. Fixes #218.