### PR TITLE
Add support for an internet radio icon

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -67,6 +67,7 @@ const PlayerState = new Lang.Class({
   trackLength: null,
   trackObj: null,
   trackRating: null,
+  isRadio: null,
 
   showPlaylist: null,
   showRating: null,
@@ -350,6 +351,7 @@ const MPRISPlayer = new Lang.Class({
       state.trackLength = metadata["mpris:length"] ? metadata["mpris:length"].unpack() / 1000000 : 0;
       state.trackObj = metadata["mpris:trackid"] ? metadata["mpris:trackid"].unpack() : "";
       state.trackCoverUrl = metadata["mpris:artUrl"] ? metadata["mpris:artUrl"].unpack() : "";
+      state.isRadio = false;
 
       if (state.trackCoverUrl !== null && state.trackCoverUrl !== this.state.trackCoverUrl) {
         if (state.trackCoverUrl) {
@@ -371,6 +373,15 @@ const MPRISPlayer = new Lang.Class({
         }
         else {
           state.trackCoverPath = '';
+        }
+      }
+      else if (state.trackCoverUrl == '') {
+        let genres = metadata["xesam:genre"].deep_unpack();
+        for (let i in genres) {
+          if (genres[i].toLowerCase().indexOf("radio") > -1) {
+            state.isRadio = true;
+            break;
+          }
         }
       }
 

--- a/src/ui.js
+++ b/src/ui.js
@@ -332,9 +332,9 @@ const PlayerUI = new Lang.Class({
       this.setActivePlaylist(newState.playlist);
     }
 
-    if (newState.trackCoverPath) {
+    if (newState.trackCoverPath || newState.isRadio) {
       this.hideCover();
-      this.showCover(newState.trackCoverPath);
+      this.showCover(newState);
     }
   },
 
@@ -358,20 +358,25 @@ const PlayerUI = new Lang.Class({
     });
   },
 
-  showCover: function(coverPath) {
+  showCover: function(state) {
     Tweener.addTween(this.trackCover, {
       opacity: 0,
       time: 0.3,
       transition: 'easeOutCubic',
       onComplete: Lang.bind(this, function() {
         // Change cover
-        if (! coverPath || ! GLib.file_test(coverPath, GLib.FileTest.EXISTS)) {
+        if (state.isRadio) {
+          let coverIcon = new St.Icon({icon_name: "radio",
+                                       icon_size: this.trackCover.child.icon_size});
+          this.trackCover.child = coverIcon;
+        }
+        else if (! state.trackCoverPath || ! GLib.file_test(state.trackCoverPath, GLib.FileTest.EXISTS)) {
           let coverIcon = new St.Icon({icon_name: "media-optical-cd-audio",
                                        icon_size: this.trackCover.child.icon_size});
           this.trackCover.child = coverIcon;
         }
         else {
-          let gicon = new Gio.FileIcon({file: Gio.File.new_for_path(coverPath)});
+          let gicon = new Gio.FileIcon({file: Gio.File.new_for_path(state.trackCoverPath)});
           let coverIcon = new St.Icon({gicon: gicon, style_class: "track-cover",
                                        icon_size: this.trackCover.child.icon_size});
           this.trackCover.child = coverIcon;


### PR DESCRIPTION
If media has no cover file and the genre contains the string "radio", use the "radio" icon instead of the "media-optical-cd-audio" icon.