### PR TITLE
Fix missing pause button

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -194,6 +194,15 @@ const MPRISPlayer = new Lang.Class({
           if (props.Volume)
             newState.volume = props.Volume.unpack();
 
+          if (props.CanPause)
+            newState.canPause = props.CanPause.unpack();
+
+          if (props.CanGoNext)
+            newState.canGoNext = props.CanGoNext.unpack();
+
+          if (props.CanGoPrevious)
+            newState.canGoPrevious = props.CanGoPrevious.unpack();
+
           if (props.PlaybackStatus) {
             let status = props.PlaybackStatus.unpack();
             if (Settings.SEND_STOP_ON_CHANGE.indexOf(this.busName) != -1) {

--- a/src/ui.js
+++ b/src/ui.js
@@ -293,10 +293,13 @@ const PlayerUI = new Lang.Class({
 
       if (status === Settings.Status.PLAY) {
         this.stopButton.show();
-        if (player.state.canPause)
+        if (player.state.canPause) {
           this.playButton.setIcon('media-playback-pause-symbolic');
-        else
+          this.playButton.show();
+        }
+        else {
           this.playButton.hide();
+        }
       }
       else if (status === Settings.Status.PAUSE) {
         this.playButton.setIcon('media-playback-start-symbolic');


### PR DESCRIPTION
When `canPause` property is false, pause button is hidden. However, there wasn't any code to show it again when `canPause` property becomes true. In addition, `PropertiesChanged` signal for this property was ignored.

*Thanks for your work on this extension.*