### PR TITLE
Add support for GNOME Shell 3.20

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ listed below).
 
 ### Manual installation
 
-Git branches `master` and `devel` work with GNOME Shell 3.10 up to 3.16+.
+Git branches `master` and `devel` work with GNOME Shell 3.10 up to 3.20+.
 
 Other branches: gnome-shell-3.0, gnome-shell-3.2, gnome-shell-3.8 (for g-s 3.4 up to 3.8)
 

--- a/src/metadata.json.in
+++ b/src/metadata.json.in
@@ -3,7 +3,7 @@
 "name": "Media player indicator",
 "description": "Control MPRIS2 capable media players: Rhythmbox, Banshee, Clementine and more. Check the home page for more details.",
 "original-author": "eon@patapon.info",
-"shell-version": [ "3.10", "3.11", "3.12", "3.14", "3.16", "3.18" ],
+"shell-version": [ "3.10", "3.11", "3.12", "3.14", "3.16", "3.18", "3.20" ],
 "url": "@URL@",
 "locale": "@LOCALEDIR@"
 }


### PR DESCRIPTION
Now that GNOME Shell has its own media player control using MPRIS
(in the calendar/messages menu), this extension is less useful than
it was in previous versions, but it is still convenient to have a way
to place media player status directly on the top bar.

Signed-off-by: Simon McVittie <smcv@debian.org>