### PR TITLE
Clear artist, album, and title when they become unavailable

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -210,7 +210,7 @@ const PlayerUI = new Lang.Class({
       }
     }
 
-    if (newState.trackTitle || newState.trackArtist || newState.trackAlbum) {
+    if (newState.trackTitle !== null || newState.trackArtist !== null || newState.trackAlbum !== null) {
       this.trackBox.empty();
       JSON.parse(Settings.gsettings.get_string(Settings.MEDIAPLAYER_TRACKBOX_TEMPLATE))
       .forEach(Lang.bind(this, function(trackInfo) {


### PR DESCRIPTION
This fixes the issue where these fields remain unchanged from the previous file even when they are unavailable in the current file.