### PR TITLE
Add placeholders for title, album, and artist

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -354,9 +354,9 @@ const MPRISPlayer = new Lang.Class({
         return;
 
       state.trackUrl = metadata["xesam:url"] ? metadata["xesam:url"].unpack() : "";
-      state.trackArtist = metadata["xesam:artist"] ? metadata["xesam:artist"].deep_unpack() : "";
-      state.trackAlbum = metadata["xesam:album"] ? metadata["xesam:album"].unpack() : "";
-      state.trackTitle = metadata["xesam:title"] ? metadata["xesam:title"].unpack() : "";
+      state.trackArtist = metadata["xesam:artist"] ? metadata["xesam:artist"].deep_unpack() : ["Unknown artist"];
+      state.trackAlbum = metadata["xesam:album"] ? metadata["xesam:album"].unpack() : "Unknown album";
+      state.trackTitle = metadata["xesam:title"] ? metadata["xesam:title"].unpack() : "Unknown title";
       state.trackNumber = metadata["xesam:trackNumber"] ? metadata["xesam:trackNumber"].unpack() : "";
       state.trackLength = metadata["mpris:length"] ? metadata["mpris:length"].unpack() / 1000000 : 0;
       state.trackObj = metadata["mpris:trackid"] ? metadata["mpris:trackid"].unpack() : "";


### PR DESCRIPTION
Similar to the built-in MPRIS client in gnome-shell 3.20, rather than showing empty strings when these fields are unavailable, display "Unknown title", "Unknown album", and "Unknown artist" instead.
