### PR TITLE
Fix MediaServer2PlaylistsIFace

### DIFF
--- a/src/dbus.js
+++ b/src/dbus.js
@@ -100,7 +100,7 @@ const MediaServer2PlaylistsIface = '<node>\
             <arg type="u" direction="in" />\
             <arg type="s" direction="in" />\
             <arg type="b" direction="in" />\
-            <arg type="a{oss}" direction="out" />\
+            <arg type="a(oss)" direction="out" />\
         </method>\
         <property name="PlaylistCount" type="u" access="read" />\
         <property name="Orderings" type="as" access="read" />\


### PR DESCRIPTION
According to MPRIS2 specification the return type of the method
"GetPlaylists" should be "a(oss)".

See: https://specifications.freedesktop.org/mpris-spec/latest/Playlists_Interface.html#Method:GetPlaylists