### PR TITLE
Make playlist interface more robust

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -288,7 +288,7 @@ const MPRISPlayer = new Lang.Class({
       this.emit('player-update', newState);
       
       //Delay call 100ms because some players make the interface available without data available in the beginning
-      GLib.timeout_add(GLib.PRIORITY_DEFAULT, 100, Lang.bind(this, function() {
+      Mainloop.timeout_add(100, Lang.bind(this, function() {
         this._getPlaylists();
         return false;
       }), null);

--- a/src/player.js
+++ b/src/player.js
@@ -287,7 +287,12 @@ const MPRISPlayer = new Lang.Class({
 
       this.emit('player-update', newState);
       
-      this._getPlaylists();
+      //Delay call 100ms because some players make the interface available without data available in the beginning
+      GLib.timeout_add(GLib.PRIORITY_DEFAULT, 100, Lang.bind(this, function() {
+        this._getPlaylists();
+        return false;
+      }), null);
+
       this._getPlayerInfo();
 
       this.emit('player-update-info', this.info);
@@ -465,10 +470,17 @@ const MPRISPlayer = new Lang.Class({
 
     _getPlaylists: function() {
       this._mediaServerPlaylists.GetPlaylistsRemote(0, 100, "Alphabetical", false, Lang.bind(this, function(playlists) {
-        if (playlists && playlists[0])
+        if (playlists && playlists[0]) {
+          if (this.state.showPlaylist == false &&
+              this._settings.get_boolean(Settings.MEDIAPLAYER_PLAYLISTS_KEY)) {
+            //Reenable showPlaylist after error
+            this.emit('player-update', new PlayerState({showPlaylist: true}));
+          }
           this.emit('player-update', new PlayerState({playlists: playlists[0]}));
-        else
+        } 
+        else {
           this.emit('player-update', new PlayerState({showPlaylist: false}));
+        }
       }));
     },
 


### PR DESCRIPTION
- Delay the initial call to get playlists because some
  palyers (e.g. Rhythmbox) do not provide data if the interface gets
  available
- Show playlists again if they where hidden because of an error
