### PR TITLE
Add support for GNOME Shell 3.22

### DIFF
--- a/src/metadata.json.in
+++ b/src/metadata.json.in
@@ -3,7 +3,7 @@
 "name": "Media player indicator",
 "description": "Control MPRIS2 capable media players: Rhythmbox, Banshee, Clementine and more. Check the home page for more details.",
 "original-author": "eon@patapon.info",
-"shell-version": [ "3.10", "3.11", "3.12", "3.14", "3.16", "3.18", "3.20" ],
+"shell-version": [ "3.10", "3.11", "3.12", "3.14", "3.16", "3.18", "3.20", "3.22" ],
 "url": "@URL@",
 "locale": "@LOCALEDIR@"
 }


### PR DESCRIPTION
In spirit of pull request #251, I suggest declaring compatibility with the newest shell version. In my tests, it works just as fine after the upgrade. This would also fix #277.