### PR TITLE
Update ActivePlaylist and PlaylistCount

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -202,6 +202,12 @@ const MPRISPlayer = new Lang.Class({
           if (props.CanGoPrevious)
             newState.canGoPrevious = props.CanGoPrevious.unpack();
 
+          if (props.PlaylistCount)
+            this._getPlaylists();
+
+          if (props.ActivePlaylist)
+            newState.playlist = props.ActivePlaylist.deep_unpack()[1][0];
+
           if (props.PlaybackStatus) {
             let status = props.PlaybackStatus.unpack();
             if (Settings.SEND_STOP_ON_CHANGE.indexOf(this.busName) != -1) {


### PR DESCRIPTION
Currently when a player updates it's ActivePlaylist prop the UI doesn't reflect that. Also if PlaylistCount changes the UI also needs to reload the playlists to reflect the change. This fixes both of those issues.