### PR TITLE
Add a trackId change as a trigger to tell the song has changed.

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -383,7 +383,7 @@ const MPRISPlayer = new Lang.Class({
       }
 
       // Check if the track has changed
-      if (state.trackUrl !== this.state.trackUrl) {
+      if (state.trackUrl !== this.state.trackUrl || state.trackObj !== this.state.trackObj) {
         this._getPosition();
         this._refreshProperties();
       }


### PR DESCRIPTION
trackId's are used thoughout the interfaces to refer to specific tracks and the docs are clear that a trackId must be present in the metadata and must be unique to a track.(even so far as if a track is repeated it should be given a new trackId)

xesam:url on the otherhand is not guaranteed to exist in the metadata and may not change on repeat especially if it is a real url pointing to the actual location of the media file.

This fixes the issue by also checking to see if the trackId has changed on a metadata refresh.