### PR TITLE
Listen for the CanSeek prop change and respond accordingly.

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -202,6 +202,14 @@ const MPRISPlayer = new Lang.Class({
           if (props.CanGoPrevious)
             newState.canGoPrevious = props.CanGoPrevious.unpack();
 
+          if (props.CanSeek) {
+            let canSeek = props.CanSeek.unpack();
+            if (this.state.canSeek !== canSeek) {
+              newState.canSeek = canSeek;
+              this._getPosition();
+            }
+          }
+
           if (props.PlaylistCount)
             this._getPlaylists();
 


### PR DESCRIPTION
If the CanSeek prop changes the extension should call this._getPosition to decide if it wants to show the position slider or not. A player may want to change this prop mid song if for example it's playing a http stream and it's buffering or hasn't finished it's initial buffering yet.