### PR TITLE
Escape all html entities

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -59,10 +59,8 @@ let compileTemplate = function(template, playerState) {
   return template.replace(/{(\w+)\|?([^}]*)}/g, function(match, fieldName, appendText) {
     let text = "";
     if (playerState[fieldName]) {
-      text = playerState[fieldName].toString()
-      .replace(/&/, "&amp;")
-      .replace(/</, "&lt;")
-      .replace(/>/, "&gt;") + appendText;
+      text = playerState[fieldName].toString() + appendText;
+      text = GLib.markup_escape_text(text, -1);
     }
     return text;
   });


### PR DESCRIPTION
The regex was lacking the global flag and only replaced the 1st instance of the entity which resulted in fields not being displayed if there is more than one instance in the field. This fixes that by using GLib.markup_escape_text to escape all html entities.