### PR TITLE
Add button to raise the player's window, when trackBox hidden

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -151,12 +151,16 @@ const PlayerUI = new Lang.Class({
     this.stopButton.hide();
     this.nextButton = new Widget.PlayerButton('media-skip-forward-symbolic',
                                               Lang.bind(this.player, this.player.next));
+    this.raiseButton = new Widget.PlayerButton('view-fullscreen-symbolic',
+                                               Lang.bind(this.player, this.player.raise));
+    this.raiseButton.hide();
 
     this.trackControls = new Widget.PlayerButtons();
     this.trackControls.addButton(this.prevButton);
     this.trackControls.addButton(this.playButton);
     this.trackControls.addButton(this.stopButton);
     this.trackControls.addButton(this.nextButton);
+    this.trackControls.addButton(this.raiseButton);
 
     this.addMenuItem(this.trackControls);
 
@@ -278,11 +282,13 @@ const PlayerUI = new Lang.Class({
 
       if (status == Settings.Status.STOP) {
         this.trackBox.hideAnimate();
+        this.raiseButton.show();
         this.volume.actor.hide();
         this.position.actor.hide();
       }
       else {
         this.trackBox.showAnimate();
+        this.raiseButton.hide();
         if (this.showVolume)
           this.volume.actor.show();
         if (this.showPosition && this.player.state.canSeek)


### PR DESCRIPTION
When the trackBox is visible, the player can be raised by clicking on the track information.  But when the trackBox is hidden, because the player is stopped, there's no way to raise the player.

This PR takes one approach, adding a button to the player controls that's visible when the trackBox is hidden.  I don't know if it's the best one, but it does work for me.

This would solve #220.