### PR TITLE
Improve the cover zoom.

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -46,7 +46,7 @@ const IndicatorPosition = {
 };
 
 const FADE_ANIMATION_TIME = 0.16;
-const COVER_SIZE = 100;
+const COVER_SIZE = 72;
 
 const Status = {
     STOP: N_("Stopped"),

--- a/src/ui.js
+++ b/src/ui.js
@@ -396,15 +396,29 @@ const PlayerUI = new Lang.Class({
 
   _toggleCover: function() {
     if (this.trackCover.child.has_style_class_name('track-cover')) {
-      let size = this.trackCover.child.icon_size,
-          targetSize;
-      if (size == Settings.COVER_SIZE)
-        targetSize = size * 2;
-      else
+        let targetSize, transition, vertical;
+      if (this.trackCover.child.icon_size == Settings.COVER_SIZE) {
+        let position = Settings.gsettings.get_enum(Settings.MEDIAPLAYER_INDICATOR_POSITION_KEY);
+        if (position == Settings.IndicatorPosition.VOLUMEMENU) { 
+          targetSize = this.trackBox.content.get_preferred_width(-1)[0];
+        }
+        else {
+          targetSize = this.trackBox.actor.get_preferred_width(-1)[0];
+        }      
+        transition = 'easeInQuad';
+        vertical = true;
+      }
+      else {
         targetSize = Settings.COVER_SIZE;
+        transition = 'easeOutQuad';
+        vertical = false;
+      }
       Tweener.addTween(this.trackCover.child, {icon_size: targetSize,
-                                               time: 0.3,
-                                               transition: 'easeInCubic'});
+                                               time: Settings.FADE_ANIMATION_TIME,
+                                               transition: transition});
+      Tweener.addTween(this.trackBox.content, {vertical: vertical,
+                                             time: Settings.FADE_ANIMATION_TIME,
+                                             transition: transition});
     }
   },
 

--- a/src/widget.js
+++ b/src/widget.js
@@ -133,16 +133,15 @@ const TrackBox = new Lang.Class({
     _init: function(cover, params) {
       params = Params.parse(params, {
         hover: false,
-        style_class: "track-box"
       });
       this.parent(params);
-      // This adds an unwanted height if the PopupBaseMenuItem is empty
-      this.actor.remove_actor(this._ornamentLabel);
 
       this._cover = cover;
+      this.content = new St.BoxLayout({style_class: "popup-menu-item", vertical: false});
+      this.content.add_child(this._cover);
       this._infos = new St.BoxLayout({style_class: "track-infos", vertical: true});
-      this.actor.add(this._cover);
-      this.actor.add(this._infos, {expand: true, y_expand: true});
+      this.content.add_child(this._infos);
+      this.actor.add(this.content);
     },
 
     addInfo: function(item, row) {
@@ -227,9 +226,8 @@ const TrackInfo = new Lang.Class({
 
     setText: function(text) {
       if (this._label.clutter_text) {
-        this._label.clutter_text.line_wrap = true;
-        this._label.clutter_text.line_wrap_mode = Pango.WrapMode.WORD_CHAR;
-        this._label.clutter_text.ellipsize = Pango.EllipsizeMode.NONE;
+        this._label.clutter_text.line_wrap = false;
+        this._label.clutter_text.ellipsize = Pango.EllipsizeMode.END;
         this._label.clutter_text.set_markup(text);
       }
     },


### PR DESCRIPTION
Move the text to under the cover when the cover is enlarged.
Fixes https://github.com/eonpatapon/gnome-shell-extensions-mediaplayer/issues/238

This is a step in the right direction and worth adding now, but there is a lot of work to be done with the layout. I would like to move to more relative placement of widgets and inherent css styles when ever possible from the current shell theme to avoid things looking out of place and not lining up correctly. Currently there's a lot of absolute sizing and placement of widgets.

Edit:

Found out how to make everything line up better by wraping it all in a "content" box and using the "popup-menu-item" style class. I also added not wrapping the text. It just looks bad, and breaks the layout. If a user really needs to read the complete text then they can expand the cover or open the player.