### PR TITLE
Improve raise behaviour

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -154,6 +154,7 @@ const PlayerUI = new Lang.Class({
     this.addMenuItem(this.trackBox);
 
     this.trackRatings = new Widget.TrackRating(this.player, 0);
+    this.trackRatings.connect('activate', Lang.bind(this.player, this.player.raise));
     this.addMenuItem(this.trackRatings);
 
     this.secondaryInfo = new Widget.SecondaryInfo();
@@ -172,6 +173,7 @@ const PlayerUI = new Lang.Class({
                                               Lang.bind(this.player, this.player.next));
 
     this.trackControls = new Widget.PlayerButtons();
+    this.trackControls.connect('activate', Lang.bind(this.player, this.player.raise));
     this.trackControls.addButton(this.prevButton);
     this.trackControls.addButton(this.playButton);
     this.trackControls.addButton(this.stopButton);

--- a/src/widget.js
+++ b/src/widget.js
@@ -39,7 +39,7 @@ const PlayerButtons = new Lang.Class({
     Extends: PopupMenu.PopupBaseMenuItem,
 
     _init: function() {
-        this.parent({reactive: false});
+        this.parent({hover: false});
         this.box = new St.BoxLayout({style_class: 'controls'});
         this.actor.add(this.box, {expand: true, x_fill: false, x_align: St.Align.MIDDLE});
     },
@@ -97,7 +97,7 @@ const SliderItem = new Lang.Class({
     Extends: PopupMenu.PopupBaseMenuItem,
 
     _init: function(icon, value) {
-        this.parent({style_class: 'slider-item'});
+        this.parent({style_class: 'slider-item', hover: false});
 
         this._icon = new St.Icon({style_class: 'popup-menu-icon', icon_name: icon});
         this._slider = new Slider.Slider(value);


### PR DESCRIPTION
Makes the control buttons and ratings boxes raise the player so that a player can be raised when it is not playing. This also sets hover for the volume and position sliders to false for visual continuity. Fixes https://github.com/eonpatapon/gnome-shell-extensions-mediaplayer/issues/220