### PR TITLE
uncouple canSeek and position slider visibility

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -402,7 +402,7 @@ const MPRISPlayer = new Lang.Class({
         canPause: this._mediaServerPlayer.CanPause || true,
         canGoNext: this._mediaServerPlayer.CanGoNext || true,
         canGoPrevious: this._mediaServerPlayer.CanGoPrevious || true,
-        canSeek: this._mediaServerPlayer.CanSeek || true,
+        canSeek: this._mediaServerPlayer.CanSeek || false,
         hasTrackList: this._mediaServer.HasTrackList || false,
         showVolume: this._settings.get_boolean(Settings.MEDIAPLAYER_VOLUME_KEY),
         showPosition: this._settings.get_boolean(Settings.MEDIAPLAYER_POSITION_KEY),
@@ -508,12 +508,9 @@ const MPRISPlayer = new Lang.Class({
       this._prop.GetRemote('org.mpris.MediaPlayer2.Player', 'CanSeek',
                            Lang.bind(this, function(value, err) {
                              let state = new PlayerState();
-                             let canSeek = true;
+                             let canSeek = false;
                              if (!err)
                                canSeek = value[0].unpack();
-
-                             if (this.state.trackLength === 0)
-                               canSeek = false;
 
                              if (this.state.canSeek != canSeek) {
                                state.canSeek = canSeek;

--- a/src/ui.js
+++ b/src/ui.js
@@ -381,17 +381,16 @@ const PlayerUI = new Lang.Class({
     }
 
     if (newState.canSeek !== null) {
-      if (newState.canSeek && this.showPosition &&
-          this.player.state.status != Settings.Status.STOP) {
-        this.position.actor.show();
-      }
-      else {
-        this.position.actor.hide();
-      }
+      this.position.setReactive(newState.canSeek)
     }
 
     if (newState.trackTime && newState.trackLength) {
-      this.position.setValue(newState.trackTime / newState.trackLength);
+      if (newState.trackLength === 0) {
+        this.position.actor.hide();
+      }
+      else {
+        this.position.setValue(newState.trackTime / newState.trackLength);
+      }
     }
 
     if (newState.status) {

--- a/src/widget.js
+++ b/src/widget.js
@@ -106,6 +106,10 @@ const SliderItem = new Lang.Class({
         this.actor.add(this._slider.actor, {expand: true});
     },
 
+    setReactive: function(reactive) {
+        this._slider.actor.reactive = reactive;
+    },
+
     setValue: function(value) {
         this._slider.setValue(value);
     },


### PR DESCRIPTION
CanSeek now sets if the position slider is reactive not visible. If the player gives us a valid trackLength and position and the user wishes the position slider shown show it.