### PR TITLE
fix no property text exception

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -87,11 +87,6 @@ function getPlayerSymbolicIcon(desktopEntry) {
 }
 
 function parseMetadata(metadata, state) {
-  // Pragha sends a metadata dict with one value on stop
-  if (metadata === null || Object.keys(metadata).length < 2) {
-    return;
-  }
-
   state.trackUrl = metadata["xesam:url"] ? metadata["xesam:url"].unpack() : "";
   state.trackArtist = metadata["xesam:artist"] ? metadata["xesam:artist"].deep_unpack() : ["Unknown artist"];
   state.trackAlbum = metadata["xesam:album"] ? metadata["xesam:album"].unpack() : "Unknown album";


### PR DESCRIPTION
There's no point in guarding parseMetadata.