### PR TITLE
Still More fixups for GNOME 3.24

### DIFF
--- a/src/manager.js
+++ b/src/manager.js
@@ -110,7 +110,10 @@ const PlayerManager = new Lang.Class({
                                                         Lang.bind(this, this._onActivePlayerUpdate));
       this.showActivePlayer();
       if (player.info.desktopEntry) {
-        player.state.desktopEntry = player.info.desktopEntry
+        player.state.desktopEntry = player.info.desktopEntry;
+      }
+      else {
+        player.state.desktopEntry = null;
       }
       this.emit('player-active-update', player.state);
     },

--- a/src/widget.js
+++ b/src/widget.js
@@ -597,7 +597,7 @@ const ListSubMenu = new Lang.Class({
     let menuItems = this.menu._getMenuItems().filter(function(item) {
         return item.obj === obj;  
     });
-    if (menuItems) {
+    if (menuItems && menuItems[0]) {
       return menuItems[0];
     }
     else {


### PR DESCRIPTION
GNOME Shell 3.24's js engine is more strict than previous versions and spams the logs with warnings.