### PR TITLE
Handle Spotify's broken MPRIS implementation

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -78,7 +78,12 @@ const ALTERNATIVE_TRACKLIST_TITLES = [
 ];
 
 const PLAYERS_THAT_CANT_STOP = [
-    "Pithos"
+    "Pithos",
+    "Spotify"
+];
+
+const BROKEN_PLAYERS = [
+    "Spotify"
 ];
 
 const IndicatorStatusType = {


### PR DESCRIPTION
Spotify's MPRIS implementation is broken:
https://community.spotify.com/t5/Desktop-Linux-Windows-Web-Player/MPRIS-Implementation-is-severely-broken-in-the-Linux-client/td-p/1661880

This disables all but the most basic functionality for Spotify as Spotify is incapable of doing much else beyond the minimum correctly.

And also makes it easier to do the same to other poorly implemented players. 