### PR TITLE
Dynamic menu width

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -93,6 +93,7 @@ function disable() {
   }
   else {
     indicator.indicators.destroy();
+    Main.panel.statusArea.aggregateMenu.menu.actor.set_width(-1);
     indicator = null;
   }
   if (Settings.MINOR_VERSION > 19) {

--- a/src/stylesheet.css
+++ b/src/stylesheet.css
@@ -1,7 +1,3 @@
-.mediaplayer-menu {
-  width: 24em;
-}
-
 .controls {
     padding-top: 0em;
     spacing: 0.25em;

--- a/src/ui.js
+++ b/src/ui.js
@@ -212,7 +212,7 @@ const PlayerUI = new Lang.Class({
 
     if (Settings.gsettings.get_boolean(Settings.MEDIAPLAYER_START_ZOOMED_KEY)) {
       this.trackCover.child.icon_size = this.largeCoverSize;
-      this.trackBox.infos.hide()      
+      this.trackBox.infos.hide();      
     }
     else {
       this.trackCover.child.icon_size = this.smallCoverSize;


### PR DESCRIPTION
Dynamically change the PanelIndicator and Aggregate Menu width based on the large cover size and the Aggregate Menu. The menu size is defined as the natural width of the Aggregate Menu or the large cover size + a small amount of padding, whichever is larger. The Aggregate Menu may grow in width depending upon theme and cover size to accommodate the cover but will return to it's default width when no active player is present and/or the extension is disabled.