### PR TITLE
silence more useless GNOME 3.24 warnings

### DIFF
--- a/src/widget.js
+++ b/src/widget.js
@@ -210,7 +210,8 @@ const SecondaryInfo = new Lang.Class({
     Extends: PopupMenu.PopupBaseMenuItem,
 
     _init: function() {
-      this.parent({hover: false});     
+      this.parent({hover: false});
+      this._hidden = false;     
       this.infos = new St.BoxLayout({vertical: true});
       this.actor.add(this.infos, {expand: true, x_fill: false, x_align: St.Align.MIDDLE});
     },


### PR DESCRIPTION
The js engine in GNOME 3.24 apparently really hates undefined. Even though the code works just fine and it's well within js code convention. They apparently think or want js to be python???