### PR TITLE
add-player-name-to-trackbox-template

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -96,7 +96,6 @@ function parseMetadata(metadata, state) {
   state.trackArtist = metadata["xesam:artist"] ? metadata["xesam:artist"].deep_unpack() : ["Unknown artist"];
   state.trackAlbum = metadata["xesam:album"] ? metadata["xesam:album"].unpack() : "Unknown album";
   state.trackTitle = metadata["xesam:title"] ? metadata["xesam:title"].unpack() : "Unknown title";
-  state.trackNumber = metadata["xesam:trackNumber"] ? metadata["xesam:trackNumber"].unpack() : "";
   state.trackLength = metadata["mpris:length"] ? metadata["mpris:length"].unpack() / 1000000 : 0;
   state.trackObj = metadata["mpris:trackid"] ? metadata["mpris:trackid"].unpack() : "/org/mpris/MediaPlayer2/TrackList/NoTrack";
   state.trackCoverUrl = metadata["mpris:artUrl"] ? metadata["mpris:artUrl"].unpack() : "";

--- a/src/org.gnome.shell.extensions.mediaplayer.gschema.xml.in
+++ b/src/org.gnome.shell.extensions.mediaplayer.gschema.xml.in
@@ -97,7 +97,7 @@
         <_description>Start with the cover zoomed.</_description>
     </key>
     <key type="s" name="trackbox-template">
-      <default>'[{"template": "{trackArtist}", "style_class": "track-info-artist"}, {"template": "{trackTitle}", "style_class": "track-info-title"}, {"template": "{trackAlbum}", "style_class": "track-info-album"}]'</default>
+      <default>'[{"template": "{playerName}", "style_class": "track-info-artist"}, {"template": "{trackArtist}", "style_class": "track-info-artist"}, {"template": "{trackTitle}", "style_class": "track-info-title"}, {"template": "{trackAlbum}", "style_class": "track-info-album"}]'</default>
       <_summary>Template to render the trackbox</_summary>
     </key>
   </schema>

--- a/src/panel.js
+++ b/src/panel.js
@@ -70,6 +70,10 @@ const IndicatorMixin = {
 
   // method binded to classes below
   _commonOnActivePlayerUpdate: function(manager, state) {
+    if (state.playerName !== null) {
+      this._playerName = state.playerName;
+    }
+
     if (this.panelIconSettingId) {
       this._settings.disconnect(this.panelIconSettingId);
     }
@@ -110,7 +114,8 @@ const IndicatorMixin = {
       this._thirdIndicator.show();
     }
 
-    if (state.trackTitle || state.trackArtist || state.trackAlbum || state.trackNumber) {
+    if (state.trackTitle || state.trackArtist || state.trackAlbum) {
+      state.playerName = this._playerName;
       let stateText = this.compileTemplate(stateTemplate, state);
       this._thirdIndicator.clutter_text.set_markup(stateText);
 
@@ -194,6 +199,7 @@ const PanelIndicator = new Lang.Class({
     this.menuResizeId = 0;
     this.currentCoverUrl = '';
     this.currentDesktopEntry = '';
+    this._playerName = '';
 
     this.indicators = new St.BoxLayout({vertical: false, style_class: 'system-status-icon'});
 
@@ -261,6 +267,7 @@ const AggregateMenuIndicator = new Lang.Class({
     this.menuResizeId = 0;
     this.currentCoverUrl = '';
     this.currentDesktopEntry = '';
+    this._playerName = '';
 
     this._primaryIndicator = this._addIndicator();
     this._primaryIndicator.icon_name = 'audio-x-generic-symbolic';

--- a/src/player.js
+++ b/src/player.js
@@ -52,6 +52,7 @@ const PlayerState = new Lang.Class({
     }
   },
 
+  playerName: null,
   status: null,
 
   playlist: null,
@@ -62,7 +63,6 @@ const PlayerState = new Lang.Class({
 
   trackTime: null,
   trackTitle: null,
-  trackNumber: null,
   trackAlbum: null,
   trackArtist: null,
   trackUrl: null,
@@ -416,7 +416,8 @@ const MPRISPlayer = new Lang.Class({
         showTracklistRating: this._settings.get_boolean(Settings.MEDIAPLAYER_TRACKLIST_RATING_KEY),
         volume: this._mediaServerPlayer.Volume || 0.0,
         status: this._mediaServerPlayer.PlaybackStatus || Settings.Status.STOP,
-        orderings: this._checkOrderings(this._mediaServerPlaylists.Orderings)
+        orderings: this._checkOrderings(this._mediaServerPlaylists.Orderings),
+        playerName: this._mediaServer.Identity || ''
       });
       if (this._mediaServerPlaylists.ActivePlaylist) {
         newState.playlist = this._mediaServerPlaylists.ActivePlaylist[1][0];

--- a/src/ui.js
+++ b/src/ui.js
@@ -327,9 +327,12 @@ const PlayerUI = new Lang.Class({
       this.secondaryInfo.empty();
       JSON.parse(Settings.gsettings.get_string(Settings.MEDIAPLAYER_TRACKBOX_TEMPLATE))
       .forEach(Lang.bind(this, function(trackInfo) {
-        let text = this.compileTemplate(trackInfo.template, newState);
-        this.trackBox.addInfo(new Widget.TrackInfo(text, trackInfo.style_class));
-        this.secondaryInfo.addInfo(new Widget.TrackInfo(text, trackInfo.style_class));
+        let template = trackInfo.template;
+        if (template != '{playerName}') {
+          let text = this.compileTemplate(template, newState);
+          this.trackBox.addInfo(new Widget.TrackInfo(text, trackInfo.style_class));
+          this.secondaryInfo.addInfo(new Widget.TrackInfo(text, trackInfo.style_class));
+        }
       }));
     }
 


### PR DESCRIPTION
Users can now put the name of the player in the panel if they want.

For example {playerName}: {trackArtist} - {trackTitle}.